### PR TITLE
GRAPH-1505 - add missing accept field in request header

### DIFF
--- a/src/com/amazon/paapi5/v1/auth/SignHelper.php
+++ b/src/com/amazon/paapi5/v1/auth/SignHelper.php
@@ -140,6 +140,7 @@ class SignHelper
         $this->awsHeaders['Host'] = $this->host;
         $this->awsHeaders['X-Amz-Date'] = $this->xAmzDate;
         $this->awsHeaders['X-Amz-Target'] = $this->buildAmzTarget();
+        $this->awsHeaders['Accept'] = 'application/json'; // added to stop getting 400 bad request errors from Amazon
 
         /* Sort headers */
         ksort($this->awsHeaders);


### PR DESCRIPTION
Add the ``Accept`` field the request header. This should address ``400 Bad Request`` responses we were getting from Amazon recently. If this works after updating the library in Product Catalog, we should be able to resume ingesting. I'm not sure why this field was missing in the first place...